### PR TITLE
Make loading translations optional

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -3,7 +3,8 @@ import { IntlProvider, intlShape } from 'react-intl';
 import { mount, shallow, render } from 'enzyme';
 let path = require('path');
 let locale = 'en';
-let messages = {};
+const defaultMessages = new Proxy({}, { get: (target, property) => property });
+let messages = defaultMessages;
 
 /**
  * Loads translation file.
@@ -12,7 +13,7 @@ let messages = {};
  */
 function loadTranslation(localeFilePath) {
     if(typeof localeFilePath == "undefined"){
-        messages = {};
+        messages = defaultMessages;
         return null;
     }
     let fp = path.join(__dirname, localeFilePath);
@@ -27,8 +28,8 @@ function loadTranslation(localeFilePath) {
  */
 function loadTranslationObject(translations) {
     if (typeof translations === "undefined") {
-        messages = {}
-        return null
+        messages = defaultMessages;
+        return null;
     }
 
     messages = translations;

--- a/test/test.js
+++ b/test/test.js
@@ -74,5 +74,17 @@ describe('enzymeReactIntl', function() {
 
             expect(wrapper.text()).to.match(/Message 1/);
         });
+        it('should render using the default translations', function () {
+            loadTranslation(undefined);
+            const wrapper = renderWithIntl(<Test />);
+
+            expect(wrapper.text()).to.equal('first_msg');
+        });
+        it('should render using the default translations 2', function () {
+            loadTranslationObject(undefined);
+            const wrapper = renderWithIntl(<Test />);
+
+            expect(wrapper.text()).to.equal('first_msg');
+        });
     });
 });


### PR DESCRIPTION
Rather than using a real translation file or a mock object where
I have to define all the possible keys. It would be easier to use
if the default behavior of the *WithIntl methods just used the
translation key as the value rendered in a component during testing.