### PR TITLE
Add getter to allow direct access to intl object

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -84,6 +84,11 @@ function setLocale(str){
     locale = str;
 }
 
+function getIntl(){
+    const intlProvider = new IntlProvider({ locale: locale, messages }, {});
+    return intlProvider.getChildContext();
+}
+
 var enzymeReactIntl = {
     loadTranslation: loadTranslation,
     loadTranslationObject: loadTranslationObject,
@@ -91,6 +96,7 @@ var enzymeReactIntl = {
     mountWithIntl: mountWithIntl,
     renderWithIntl: renderWithIntl,
     setLocale: setLocale,
-    getLocale: getLocale
+    getLocale: getLocale,
+    getIntl: getIntl
 };
 module.exports = enzymeReactIntl;

--- a/test/test.js
+++ b/test/test.js
@@ -1,4 +1,5 @@
 require("./jsdomSetup.js");
+import { IntlProvider } from 'react-intl';
 
 import React from 'react';
 import chai, {expect, assert} from 'chai';
@@ -9,7 +10,7 @@ chai.use(chaiSubset);
 import chaiEnzyme from 'chai-enzyme';
 chai.use(chaiEnzyme());
 
-import { loadTranslation, loadTranslationObject, shallowWithIntl, mountWithIntl, renderWithIntl, setLocale, getLocale } from '../src/index.js';
+import { loadTranslation, loadTranslationObject, shallowWithIntl, mountWithIntl, renderWithIntl, setLocale, getLocale, getIntl } from '../src/index.js';
 import Test from './testComponent.jsx';
 import jsonfile from 'jsonfile';
 
@@ -31,6 +32,17 @@ describe('enzymeReactIntl', function() {
             const localeGet = getLocale();
 
             expect(localeSet).to.equal(localeGet);
+        });
+    });
+    describe('getIntl', function() {
+        it('should return an intl object', function () {
+
+            const intlProvider = new IntlProvider({locale: 'en-GB', messages: {} }, {});
+            const { intl } = intlProvider.getChildContext();
+
+            const intlGet = getIntl();
+
+            expect(intlGet.intl).to.have.all.keys( intl );
         });
     });
     describe('loadTranslation', function() {


### PR DESCRIPTION
- Added a getter for direct access to the intl object
- Added a test for new getIntl method

This is to address a quirky little problem we have encountered, whereby we need to pass an intl object into one of our Redux actions. Our current workaround is :
- pass the ```messages``` object that we create in enzyme in our common setup to our tests
- create new intl object in test as required and pass into tests directly

Having an intl getter in this package will mean we can just grab the intl object with all messages/locale already set and pass it straight in to our tests (which would be lovely).

Note - I had some fun and games getting these tests running, looks like maybe mocha-webpack isn't compatible with versions of webpack newer than 3.11.0.  I rolled a few things back and made a few hacks here and there to get the tests running enough that I could check my new test worked as expected.  Didn't PR my hacky changes to the repo, but can do if required.
https://github.com/thefossedog/enzyme-react-intl/tree/hackityhack

And finally - Awesome tool mate - thanks for your work on this
